### PR TITLE
Fix links. Add Discussion link

### DIFF
--- a/content/pages/get-involved.mdx
+++ b/content/pages/get-involved.mdx
@@ -6,7 +6,7 @@ There are a few ways you can get involved:
 - Watch or star [OpenGitOps project repos](https://github.com/open-gitops/project/blob/main/README.md#repositories) and [GitOps Working Group](https://github.com/gitops-working-group/gitops-working-group/) repo to see when things change
 - Join the [GitOps Subreddit](https://www.reddit.com/r/GitOps/)
 - Attend a [Working Group or Committee meeting](https://github.com/gitops-working-group/gitops-working-group/blob/main/MEETINGS.md)
-- Start a [Discussion](https://github.com/open-gitops/project/discussions)
+- Start or participate in [Discussions](https://github.com/open-gitops/project/discussions)
 - [Open an issue](https://github.com/open-gitops/project/issues) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
 - Join the [SIG App Delivery](https://github.com/cncf/sig-app-delivery) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`

--- a/content/pages/get-involved.mdx
+++ b/content/pages/get-involved.mdx
@@ -3,14 +3,15 @@
 The GitOps Working Group is an open group, inviting companies and individuals to join and contribute to the community and the adoption of GitOps across the cloud native landscape.
 There are a few ways you can get involved:
 
-- Watch or star this repo to see when things change
+- Watch or star [OpenGitOps project repos](https://github.com/open-gitops/project/blob/main/README.md#repositories) and [GitOps Working Group](https://github.com/gitops-working-group/gitops-working-group/) repo to see when things change
 - Join the [GitOps Subreddit](https://www.reddit.com/r/GitOps/)
-- Attend a [Working Group or Committee meeting](./MEETINGS.md)
-- [Open an issue](/../../issues/new) and let us know how you're using GitOps and any important considerations we should include
+- Attend a [Working Group or Committee meeting](https://github.com/gitops-working-group/gitops-working-group/blob/main/MEETINGS.md)
+- Start a [Discussion](https://github.com/open-gitops/project/discussions)
+- [Open an issue](https://github.com/open-gitops/project/issues) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
 - Join the [SIG App Delivery](https://github.com/cncf/sig-app-delivery) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`
 - See [Working Group project boards](https://github.com/orgs/gitops-working-group/projects) for status of work, or for ideas on areas that could use additional participation
-- Volunteer to join [committees](GOVERNANCE.md#committees) and help with projects according to your interest and ability
+- Volunteer to join [committees](https://github.com/gitops-working-group/gitops-working-group/blob/main/GOVERNANCE.md#committees) and help with projects according to your interest and ability
 
 The Working Group will review all open issues and PRs at our regular working group meeting (schedule coming soon).
 


### PR DESCRIPTION
Fixes #14

Ultimately this content will be ingested from their original sources in git.
Until then, duplicate info here.