### PR TITLE
Specify principles version

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -96,7 +96,8 @@ const IndexPage = ({ location }) => {
             <div className="w-full lg:w-2/5">
               <h2 className="mb-12 pr-64 text-5xl md:text-6xl lg:sticky lg:top-12 xl:text-7xl lg:mb-0">
                 <span className="text-accent">GitOps</span>{" "}
-                <span className="font-normal">Principles</span>
+                <span className="font-normal">Principles</span>{" "}
+                <span className="font-normal sm:text-3xl"><a href="https://github.com/open-gitops/documents/releases/tag/v0.1.0">v0.1.0</a></span>
               </h2>
             </div>
 


### PR DESCRIPTION
Specifies that the GitOps Principles version currently being shown is [v0.1.0](https://github.com/open-gitops/documents/releases/tag/v0.1.0).

- [x] temporarily include build fix cherry-picked from https://github.com/open-gitops/website/pull/17 so we can preview

<img width="1304" alt="Screen Shot 2021-07-27 at 7 55 56 PM" src="https://user-images.githubusercontent.com/407675/127242305-fa737925-b608-44e4-a1d1-49bf282374ee.png">
