### PR TITLE
Add Github Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy Gatsby
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run build
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
 
-
 jobs:
   deploy:
     name: Deploy

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-opengitops.dev

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+opengitops.dev


### PR DESCRIPTION
Closes #27 

Create a Github action using the "peaceiris/actions-gh-pages" action step to deploy to Github pages. Uses the `contents: write` permission to gain write access to branches (through the `GITHUB_TOKEN` secret). 

Added a CNAME file for consistency with Github pages documentation.