### PR TITLE
Adding highlight colors to hyperlinks

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -10,3 +10,4 @@
 a:not([class]) {
   @apply text-accent;
 }
+


### PR DESCRIPTION
Per request from @todaywasawesome, here is some CSS that pulls in a Tailwind token to apply color to hyperlinks without a classname.