### PR TITLE
fix(package.json): disable Gatsby telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "gatsby"
   ],
   "scripts": {
-    "develop": "gatsby develop",
-    "start": "gatsby develop",
-    "build": "gatsby build",
-    "serve": "gatsby serve",
-    "clean": "gatsby clean",
-    "deploy": "gatsby build && gh-pages -d public -b gh-pages"
+    "develop": "GATSBY_TELEMETRY_DISABLED=1 gatsby develop",
+    "start": "GATSBY_TELEMETRY_DISABLED=1 gatsby develop",
+    "build": "GATSBY_TELEMETRY_DISABLED=1 gatsby build",
+    "serve": "GATSBY_TELEMETRY_DISABLED=1 gatsby serve",
+    "clean": "GATSBY_TELEMETRY_DISABLED=1 gatsby clean",
+    "deploy": "GATSBY_TELEMETRY_DISABLED=1 gatsby build && gh-pages -d public -b gh-pages"
   },
   "dependencies": {
     "@animated-burgers/burger-squeeze": "^1.1.2",


### PR DESCRIPTION
To test this:
```
    rm -rf ~/.config/gatsby
    npm i
    npm start
```
or:
```
    rm -rf ~/.config/gatsby
    yarn install
    yarn start
```
and the following message should no longer appear
... when locally developing open-gitops/website
```
╔════════════════════════════════════════════════════════════════════════╗
║                                                                        ║
║   Gatsby collects anonymous usage analytics                            ║
║   to help improve Gatsby for all users.                                ║
║                                                                        ║
║   If you'd like to opt-out, you can use `gatsby telemetry --disable`   ║
║   To learn more, checkout https://gatsby.dev/telemetry                 ║
║                                                                        ║
╚════════════════════════════════════════════════════════════════════════╝
```