### PR TITLE
docs(get-involved.mdx): fix broken meetings link

### DIFF
--- a/content/pages/get-involved.mdx
+++ b/content/pages/get-involved.mdx
@@ -5,7 +5,7 @@ There are a few ways you can get involved:
 
 - Watch or star [OpenGitOps project repos](https://github.com/open-gitops/project/blob/main/README.md#repositories) and [GitOps Working Group](https://github.com/gitops-working-group/gitops-working-group/) repo to see when things change
 - Join the [GitOps Subreddit](https://www.reddit.com/r/GitOps/)
-- Attend a [Working Group or Committee meeting](https://github.com/gitops-working-group/gitops-working-group/blob/main/MEETINGS.md)
+- Attend a [Working Group or Committee meeting](https://github.com/gitops-working-group/gitops-working-group/#meetings)
 - Start or participate in [Discussions](https://github.com/open-gitops/project/discussions)
 - [Open an issue](https://github.com/open-gitops/project/issues) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)


### PR DESCRIPTION
https://github.com/gitops-working-group/gitops-working-group/pull/163 removed the `MEETINGS.md` document in favor of documenting meetings within the `README.md`.