### PR TITLE
docs(get-involved.mdx): Fix gitops-wg repo URL

### DIFF
--- a/content/pages/get-involved.mdx
+++ b/content/pages/get-involved.mdx
@@ -3,7 +3,7 @@
 The GitOps Working Group is an open group, inviting companies and individuals to join and contribute to the community and the adoption of GitOps across the cloud native landscape.
 There are a few ways you can get involved:
 
-- Watch or star [OpenGitOps project repos](https://github.com/open-gitops/project/blob/main/README.md#repositories) and [GitOps Working Group](https://github.com/gitops-working-group/gitops-working-group/) repo to see when things change
+- Watch or star [OpenGitOps project repo](https://github.com/open-gitops/project/blob/main/README.md#repositories) and [CNCF Application Delivery TAG: GitOps Working Group folder](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg) to see when things change
 - Join the [GitOps Subreddit](https://www.reddit.com/r/GitOps/)
 - Attend a [Working Group or Committee meeting](https://github.com/gitops-working-group/gitops-working-group/blob/main/MEETINGS.md)
 - Start or participate in [Discussions](https://github.com/open-gitops/project/discussions)


### PR DESCRIPTION
https://github.com/gitops-working-group/gitops-working-group/
→
https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg

Signed-off-by: lloydchang <lloydchang@gmail.com>