### PR TITLE
fix(components/events): fix empty events list rendering

### DIFF
--- a/src/components/events.js
+++ b/src/components/events.js
@@ -47,7 +47,7 @@ const Events = ({ upcomingLimit, pastLimit }) => {
       <Map className="absolute -z-1 top-12 left-[40%] h-auto w-[140%] sm:w-[1700px] text-[#4d8dff]" />
 
       <Container>
-        {upcomingtEvents.length && (
+        {upcomingtEvents.length > 0 && (
           <React.Fragment>
             <h2>
               Upcomings <span className="text-accent">Events</span>
@@ -77,7 +77,7 @@ const Events = ({ upcomingLimit, pastLimit }) => {
           </React.Fragment>
         )}
 
-        {pastEvents.length && (
+        {pastEvents.length > 0 && (
           <React.Fragment>
             <h2 className="mt-20 text-3xl lg:mt-32">
               Past <span className="text-accent">Events</span>


### PR DESCRIPTION
This PR fixes `Events` component rendering in the case where the event list (`upcomingtEvents/pastEvents`) does not contain elements.

Rendering failure screenshot ([https://opengitops.dev](https://opengitops.dev), 12/31/2021):

![Captura de pantalla 2021-12-31 a las 21 12 36](https://user-images.githubusercontent.com/24798262/147838149-861d75f9-0ae0-4432-9403-6097793158ef.png)

