### PR TITLE
fix: package lock files for website deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "gatsby-plugin-sass": "^4.8.0",
         "gatsby-plugin-sharp": "^3.8.0",
         "gatsby-plugin-sitemap": "^4.4.0",
+        "gatsby-remark-autolink-headers": "^4.11.0",
         "gatsby-remark-images": "^5.5.0",
         "gatsby-remark-prismjs": "^5.5.0",
         "gatsby-source-filesystem": "^3.8.0",
@@ -1440,9 +1441,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -10560,6 +10561,26 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
       "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+    },
+    "node_modules/gatsby-remark-autolink-headers": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.11.0.tgz",
+      "integrity": "sha512-wklhIRpVQfv9xMPoSVKDl/DRLBzxKWr13PRQgw602zVmj/IdMzgVarJgU8aCzlyb3+JztlptnKE1U/htFs8HGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.21",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^3.0.0-next.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
+      }
     },
     "node_modules/gatsby-remark-images": {
       "version": "5.6.0",
@@ -24898,9 +24919,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -33067,6 +33088,18 @@
           "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
           "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
         }
+      }
+    },
+    "gatsby-remark-autolink-headers": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.11.0.tgz",
+      "integrity": "sha512-wklhIRpVQfv9xMPoSVKDl/DRLBzxKWr13PRQgw602zVmj/IdMzgVarJgU8aCzlyb3+JztlptnKE1U/htFs8HGQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.21",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.3"
       }
     },
     "gatsby-remark-images": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gatsby-plugin-sass": "^4.8.0",
     "gatsby-plugin-sharp": "^3.8.0",
     "gatsby-plugin-sitemap": "^4.4.0",
-    "gatsby-remark-autolink-headers": "^5.7.0",
+    "gatsby-remark-autolink-headers": "^4.11.0",
     "gatsby-remark-images": "^5.5.0",
     "gatsby-remark-prismjs": "^5.5.0",
     "gatsby-source-filesystem": "^3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6625,10 +6625,10 @@
     "xstate" "^4.9.1"
     "yoga-layout-prebuilt" "^1.9.6"
 
-"gatsby-remark-autolink-headers@^5.7.0":
-  "integrity" "sha512-scUhTzfDNCK/WCke/5LeelzjZVZx5TpmWOvka43DJBn1UuazLesah7fzJRZJhFGp0IjEt1AOAvVXSOyBc92sGg=="
-  "resolved" "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.7.0.tgz"
-  "version" "5.7.0"
+"gatsby-remark-autolink-headers@^4.11.0":
+  "integrity" "sha512-wklhIRpVQfv9xMPoSVKDl/DRLBzxKWr13PRQgw602zVmj/IdMzgVarJgU8aCzlyb3+JztlptnKE1U/htFs8HGQ=="
+  "resolved" "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.11.0.tgz"
+  "version" "4.11.0"
   dependencies:
     "@babel/runtime" "^7.15.4"
     "github-slugger" "^1.3.0"
@@ -6750,7 +6750,7 @@
   dependencies:
     "@babel/core" "^7.14.0"
 
-"gatsby@^3.6.2":
+"gatsby@^3.0.0-next.0", "gatsby@^3.6.2":
   "integrity" "sha512-cBM5Ak4uWMg/eI4du776NIqymGdiQH6qYPvDYdxTItjDrJxZz13Fs3k8fRBgKyGq9xh3+48FLjdSikK2ZUaQXA=="
   "resolved" "https://registry.npmjs.org/gatsby/-/gatsby-3.9.0.tgz"
   "version" "3.9.0"
@@ -11836,7 +11836,7 @@
     "strip-ansi" "6.0.0"
     "text-table" "0.2.0"
 
-"react-dom@^17.0.1":
+"react-dom@^16.9.0 || ^17.0.0", "react-dom@^17.0.1":
   "integrity" "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
   "version" "17.0.2"
@@ -11900,7 +11900,7 @@
   dependencies:
     "@emotion/react" "^11.1.4"
 
-"react@^17.0.1":
+"react@^16.9.0 || ^17.0.0", "react@^17.0.1":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"


### PR DESCRIPTION
This PR fixes the deployment error mentioned in #64 which can be viewed in Actions run [here](https://github.com/open-gitops/website/runs/5186973902?check_suite_focus=true). 

I checked the working `npm ci` command locally which was succesful.

This PR also lowers the newly added `gatsby-remark-autolink-headers` plugin version since it showed incompatibility warnings in the console while installing because of a missing dependency of `gatbsy@4`.