### PR TITLE
chore: Remove press release files

### DIFF
--- a/content/press-releases/press-release-1.mdx
+++ b/content/press-releases/press-release-1.mdx
@@ -1,5 +1,0 @@
----
-title: Press release title 1
-date: "2015-05-01T22:12:03.284Z"
-url: https://github.com/open-gitops
----

--- a/content/press-releases/press-release-2.mdx
+++ b/content/press-releases/press-release-2.mdx
@@ -1,5 +1,0 @@
----
-title: Press release title 2
-date: "2015-05-01T22:12:03.284Z"
-url: https://github.com/open-gitops
----

--- a/content/press-releases/press-release-3.mdx
+++ b/content/press-releases/press-release-3.mdx
@@ -1,5 +1,0 @@
----
-title: Press release title 3
-date: "2015-05-01T22:12:03.284Z"
-url: https://github.com/open-gitops
----

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -2,7 +2,6 @@ import * as React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import PressReleases from "../components/press-releases"
 import MdxContent from "../components/ui/mdx-content"
 import { Container } from "../components/ui/grid"
 import ContentWrapper from "../components/ui/content-wrapper"
@@ -36,8 +35,6 @@ const AboutPage = ({ location }) => {
         <ContentWrapper>
           <MdxContent>{query.mdx.body}</MdxContent>
         </ContentWrapper>
-
-        <PressReleases className="mt-20" />
       </Container>
     </Layout>
   )


### PR DESCRIPTION
This PR will remove the Press Release section of the About page as mentioned in the comments of #64 . I kept the component in the code base for possible future use. Please tell me if this should be removed too.

Blocked by #66. Please merge this PR after the `.lock` file one to ensure a working deployment.