### PR TITLE
docs: Update mailing list link to go to CNCF list

### DIFF
--- a/content/pages/get-involved.mdx
+++ b/content/pages/get-involved.mdx
@@ -9,7 +9,7 @@ There are a few ways you can get involved:
 - Start or participate in [Discussions](https://github.com/open-gitops/project/discussions)
 - [Open an issue](https://github.com/open-gitops/project/issues) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
-- Join the [SIG App Delivery](https://github.com/cncf/sig-app-delivery) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`
+- Join the [SIG App Delivery](https://lists.cncf.io/g/cncf-tag-app-delivery/topics) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`
 - Volunteer to join [committees](https://github.com/open-gitops/project/blob/main/GOVERNANCE.md#committees) and help with projects according to your interest and ability
 
 The Working Group will review all open issues and PRs.


### PR DESCRIPTION
The mailing list URL now uses the link of the CNCF mailing list