### PR TITLE
Chore: remove press releases

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -130,14 +130,6 @@ module.exports = {
     {
       resolve: "gatsby-source-filesystem",
       options: {
-        name: "press-releases",
-        path: "./content/press-releases/",
-      },
-      __key: "press-releases",
-    },
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
         name: "pages",
         path: "./content/pages",
       },

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -2,7 +2,6 @@ import * as React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import PressReleases from "../components/press-releases"
 import MdxContent from "../components/ui/mdx-content"
 import { Container } from "../components/ui/grid"
 import ContentWrapper from "../components/ui/content-wrapper"
@@ -36,8 +35,6 @@ const AboutPage = ({ location }) => {
         <ContentWrapper>
           <MdxContent>{query.mdx.body}</MdxContent>
         </ContentWrapper>
-
-        <PressReleases className="mt-20" />
       </Container>
     </Layout>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,7 +56,7 @@ const IndexPage = ({ location }) => {
 
                   <AnchorLink
                     to="/#events"
-                    title="Principles"
+                    title="Upcoming Events"
                     className="font-bold text-accent hover:underline">
                     <span>Upcoming Events</span>
                   </AnchorLink>
@@ -97,7 +97,11 @@ const IndexPage = ({ location }) => {
               <h2 className="mb-12 pr-64 text-5xl md:text-6xl lg:sticky lg:top-12 xl:text-7xl lg:mb-0">
                 <span className="text-accent">GitOps</span>{" "}
                 <span className="font-normal">Principles</span>{" "}
-                <span className="font-normal sm:text-3xl"><a href="https://github.com/open-gitops/documents/releases/tag/v1.0.0">v1.0.0</a></span>
+                <span className="font-normal sm:text-3xl">
+                  <a href="https://github.com/open-gitops/documents/releases/tag/v1.0.0">
+                    v1.0.0
+                  </a>
+                </span>
               </h2>
             </div>
 


### PR DESCRIPTION
I forgot to remove the `PressRelease` also from the about page. This is done now. While trying to build the Gatsby page I saw that the filesystem plugin throws an error because it can't find the `press-release` directory which I removed earlier. This should also be fixed now.
Sorry about the issue of deploying again 🙃 