### PR TITLE
Update the SEO components of about, community, get-involved

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -21,8 +21,8 @@ const AboutPage = ({ location }) => {
   return (
     <Layout location={location}>
       <Seo
-        title="Events"
-        description="Events"
+        title="About"
+        description="The GitOps Working Group is a WG under the CNCF App Delivery SIG. The focus of the GitOps WG is to clearly define a vendor-neutral, principle-led meaning of GitOps."
         url={location.href}
         image={thumbnail}
       />

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -12,7 +12,7 @@ const AboutPage = ({ location }) => {
     <Layout location={location}>
       <Seo
         title="Community"
-        description="Community Description"
+        description="Where to find the OpenGitOps project online."
         url={location.href}
         image={thumbnail}
       />

--- a/src/pages/get-involved.js
+++ b/src/pages/get-involved.js
@@ -22,8 +22,8 @@ const GetInvolvedPage = ({ location }) => {
   return (
     <Layout location={location}>
       <Seo
-        title="Events"
-        description="Events"
+        title="Get Involved"
+        description="The GitOps Working Group is an open group, inviting companies and individuals to join and contribute to the community and the adoption of GitOps across the cloud native landscape. There are a few ways you can get involved."
         url={location.href}
         image={thumbnail}
       />


### PR DESCRIPTION
Since some of the components had the wrong name set for SEO things I updated these and also added a proper description for it. The description of about and get-involved comes from the first few paragraphs of the page itself.