### PR TITLE
Update wrong link format for working group link

### DIFF
--- a/content/pages/get-involved.mdx
+++ b/content/pages/get-involved.mdx
@@ -5,7 +5,7 @@ There are a few ways you can get involved:
 
 - Watch or star [OpenGitOps project repo](https://github.com/open-gitops/project/blob/main/README.md#repositories) and [CNCF Application Delivery TAG: GitOps Working Group folder](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg) to see when things change
 - Join the [GitOps Subreddit](https://www.reddit.com/r/GitOps/)
-- Attend a [Working Group or Committee meeting](Attend a [Working Group or Committee meeting](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg#meetings))
+- Attend a [Working Group or Committee meeting](https://github.com/cncf/tag-app-delivery/tree/main/gitops-wg#meetings)
 - Start or participate in [Discussions](https://github.com/open-gitops/project/discussions)
 - [Open an issue](https://github.com/open-gitops/project/issues) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)


### PR DESCRIPTION
On the `get-involved` page there was a mistake with the link format. Probably due to a merge conflict on that line. So this PR resolves the link format issue