### PR TITLE
Fix sorting upcoming events ascending

### DIFF
--- a/src/components/events.js
+++ b/src/components/events.js
@@ -30,11 +30,13 @@ const Events = ({ upcomingLimit, pastLimit }) => {
     `
   )
 
-  const upcomingtEvents = query.allMdx.edges.filter(event => {
-    const eventDate = event.node.frontmatter?.date
-    const startDate = new Date(eventDate)
-    return eventDate ? startDate > date : false
-  })
+  const upcomingEvents = query.allMdx.edges
+    .filter(event => {
+      const eventDate = event.node.frontmatter?.date
+      const startDate = new Date(eventDate)
+      return eventDate ? startDate > date : false
+    })
+    .sort((a, b) => a.node.frontmatter?.date < b.node.frontmatter?.date)
 
   const pastEvents = query.allMdx.edges.filter(event => {
     const eventDate = event.node.frontmatter?.date
@@ -47,7 +49,7 @@ const Events = ({ upcomingLimit, pastLimit }) => {
       <Map className="absolute -z-1 top-12 left-[40%] h-auto w-[140%] sm:w-[1700px] text-[#4d8dff]" />
 
       <Container>
-        {upcomingtEvents.length > 0 && (
+        {upcomingEvents.length > 0 && (
           <React.Fragment>
             <h2>
               Upcomings <span className="text-accent">Events</span>
@@ -55,7 +57,7 @@ const Events = ({ upcomingLimit, pastLimit }) => {
             <p>Today, {date.toDateString()}</p>
 
             <div className="mt-12 max-w-4xl space-y-7">
-              {upcomingtEvents.map(
+              {upcomingEvents.map(
                 (item, index) =>
                   index < upcomingLimit && (
                     <CardEvent


### PR DESCRIPTION
Right now the dates in the upcoming section where sorted descending. Since this is a bit misleading I changed this order to show the closest date on top of the table.
Also fixes a typo I found while going through the code