### PR TITLE
feature: Use internal Link component

### DIFF
--- a/src/components/ui/banner.js
+++ b/src/components/ui/banner.js
@@ -1,6 +1,11 @@
+import { Link } from "gatsby"
 import * as React from "react"
 
 const Banner = ({ description, shortDescription, emoji, announcementLink }) => {
+  const isExternalLink =
+    announcementLink.indexOf("http://") === 0 ||
+    announcementLink.indexOf("https://") === 0
+
   return (
     <div className="bg-accent">
       <div className="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
@@ -9,18 +14,37 @@ const Banner = ({ description, shortDescription, emoji, announcementLink }) => {
             {emoji && <span className="flex p-2 text-4xl">{emoji}</span>}
             <p className="ml-3 truncate font-bold text-2xl text-night">
               {announcementLink ? (
-                <>
-                  <a
-                    href={announcementLink}
-                    className="md:hidden hover:underline hover:text-night">
-                    {shortDescription}
-                  </a>
-                  <a
-                    href={announcementLink}
-                    className="hidden md:inline hover:underline hover:text-night">
-                    {description}
-                  </a>
-                </>
+                isExternalLink ? (
+                  <>
+                    <a
+                      href={announcementLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="md:hidden hover:underline hover:text-night">
+                      {shortDescription}
+                    </a>
+                    <a
+                      href={announcementLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hidden md:inline hover:underline hover:text-night">
+                      {description}
+                    </a>
+                  </>
+                ) : (
+                  <>
+                    <Link
+                      to={announcementLink}
+                      className="md:hidden hover:underline hover:text-night">
+                      {shortDescription}
+                    </Link>
+                    <Link
+                      to={announcementLink}
+                      className="hidden md:inline hover:underline hover:text-night">
+                      {description}
+                    </Link>
+                  </>
+                )
               ) : (
                 <>
                   <span className="md:hidden">{shortDescription}</span>


### PR DESCRIPTION
Since Gatsby has it's own Link component to route to internal pages which is a lot faster than the simple `a` tag, this is now used. Also checking for external links with a simple check for `http` or ´https` at the start of the URL. This should do the trick for most of the external URLs.