### PR TITLE
Update pr-check.yml

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check:
     name: Pull Request Lint/Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node


### PR DESCRIPTION
CI jobs are no longer running due to using an old ubuntu version that is no longer supported. 