### PR TITLE
Update banner for colocated events and remove gitopscon for now

### DIFF
--- a/content/events/gitopscon-na-2025.mdx
+++ b/content/events/gitopscon-na-2025.mdx
@@ -1,6 +1,0 @@
----
-title: GitOpsCon NA 2025
-date: "2025-11-10"
-location: "Kubecon - Atlanta, Georgia USA"
-attend: https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/gitopscon/
----

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -24,9 +24,9 @@ const Header = ({ color, hasBanner }) => {
         <div className="pb-4">
           <Banner
             emoji={"🖥️"}
-            description={"Join us at GitOpsCon Europe 2025 VIRTUAL (May 28, 2025)"}
-            shortDescription={"Register Here!"}
-            announcementLink={"https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-gitopscon-europe-2025-virtual/"}
+            description={"Join us in Atlanta for ArgoCon and FluxCon colocated with KubeCon! (Nov 10, 2025)"}
+            shortDescription={"Colocated Events Registration"}
+            announcementLink={"https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/about-co-located-events/"}
           />
         </div>
       )}

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -23,7 +23,7 @@ const Header = ({ color, hasBanner }) => {
       {hasBanner && (
         <div className="pb-4">
           <Banner
-            emoji={"🖥️"}
+            emoji={"☁️"}
             description={"Join us in Atlanta for ArgoCon and FluxCon colocated with KubeCon! (Nov 10, 2025)"}
             shortDescription={"Colocated Events Registration"}
             announcementLink={"https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/about-co-located-events/"}


### PR DESCRIPTION
Update the banner for the next event and remove GitOpsCon NA until it's rescheduled. 